### PR TITLE
Add loading indicators

### DIFF
--- a/react-app/src/components/FaceRecLoadingOverlay.jsx
+++ b/react-app/src/components/FaceRecLoadingOverlay.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+function FaceRecLoadingOverlay(props) {
+  const {
+    hide,
+    text,
+  } = {
+    hide: false,
+    text: 'Loading...',
+    ...props,
+  }
+
+  const rootStyle = {
+    margin: 0,
+    padding: 0,
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    // backgroundColor: 'rgb(0, 0, 0, .4)'
+  }
+
+  return (
+    <div style={rootStyle}>
+      { hide ||
+        <h2
+          style={{
+            color: 'white',
+            padding: '12px',
+            margin: '0px',
+            textShadow: '0px 0px 8px #000000',
+          }}
+        >
+          { text }
+        </h2>
+      }
+    </div>
+  )
+}
+
+export default FaceRecLoadingOverlay;

--- a/react-app/src/components/FaceRecVideoPlayer.jsx
+++ b/react-app/src/components/FaceRecVideoPlayer.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import FaceRecVideo from './FaceRecVideo'
+import FaceRecLoadingOverlay from './FaceRecLoadingOverlay'
 
 //  Temporarily utilize hard-coded test images
 const referenceImagePaths = [
@@ -51,6 +52,7 @@ function FaceRecVideoPlayer(props) {
 
   return (<>
     <div style={rootStyle}>
+      {/* Video playback */}
       <div style={{...centeredRowStyle, paddingBottom: '12px'}}>
         {
           videoPlaying
@@ -68,7 +70,7 @@ function FaceRecVideoPlayer(props) {
                   height: videoHeight,
                   width: videoWidth,
                   backgroundColor: 'gray',
-                    display: 'flex',
+                  display: 'flex',
                   justifyContent: 'center',
                   alignItems: 'center',
                 }}
@@ -79,6 +81,21 @@ function FaceRecVideoPlayer(props) {
               </div>
         }
       </div>
+
+      {/* TODO: Maybe move within FaceRecVideo directly */}
+      <div
+        style={{
+          zIndex: 1000,
+          position: 'absolute',
+          height: videoHeight,
+          width: videoWidth,
+        }}
+      >
+        <FaceRecLoadingOverlay
+        />
+      </div>
+
+      {/* Button panel action area */}
       <div style={{...centeredRowStyle, paddingBottom: '12px'}}>
         <span style={{padding: '0px 12px'}}>
           Video Stream:

--- a/react-app/src/components/FaceRecVideoPlayer.jsx
+++ b/react-app/src/components/FaceRecVideoPlayer.jsx
@@ -1,3 +1,10 @@
+/*
+ * Component that wraps FaceRecVideo to enhance it's functionality
+ *
+ * Adds control over playback as well as various QoL features, such as loading
+ * indicators
+ */
+
 import React from 'react'
 import FaceRecVideo from './FaceRecVideo'
 import FaceRecLoadingOverlay from './FaceRecLoadingOverlay'
@@ -14,6 +21,8 @@ function FaceRecVideoPlayer(props) {
   const [videoHeight, ] = React.useState('560px')
   const [videoPlaying, setVideoPlaying] = React.useState(true)
   const [recPlaying, setRecPlaying] = React.useState(false)
+
+  const [loading, setLoading] = React.useState(false)
 
   const rootStyle = {
     margin: 0,
@@ -50,6 +59,10 @@ function FaceRecVideoPlayer(props) {
     setRecPlaying(false)
   }
 
+  const onLoadingChange = React.useCallback((val) => {
+    setLoading(val)
+  }, [setLoading])
+
   return (<>
     <div style={rootStyle}>
       {/* Video playback */}
@@ -63,6 +76,7 @@ function FaceRecVideoPlayer(props) {
                 width={videoWidth}
                 videoPlaying={videoPlaying}
                 recPlaying={recPlaying}
+                onLoadingChange={onLoadingChange}
               />
             :
               <div
@@ -82,7 +96,6 @@ function FaceRecVideoPlayer(props) {
         }
       </div>
 
-      {/* TODO: Maybe move within FaceRecVideo directly */}
       <div
         style={{
           zIndex: 1000,
@@ -92,6 +105,7 @@ function FaceRecVideoPlayer(props) {
         }}
       >
         <FaceRecLoadingOverlay
+          hide={!loading}
         />
       </div>
 

--- a/react-app/src/components/FaceRecVideoPlayer.jsx
+++ b/react-app/src/components/FaceRecVideoPlayer.jsx
@@ -114,21 +114,34 @@ function FaceRecVideoPlayer(props) {
         <span style={{padding: '0px 12px'}}>
           Video Stream:
         </span>
-        <button onClick={onStartVideoClick}>
+        <button
+          onClick={onStartVideoClick}
+          disabled={loading}
+        >
           Start
         </button>
-        <button onClick={onStopVideoClick}>
+        <button
+          onClick={onStopVideoClick}
+          disabled={loading}
+        >
           Stop
         </button>
       </div>
+
       <div style={centeredRowStyle}>
         <span style={{padding: '0px 12px'}}>
           Facial Recognition:
         </span>
-        <button onClick={onStartRecClick}>
+        <button
+          onClick={onStartRecClick}
+          disabled={loading}
+        >
           Start
         </button>
-        <button onClick={onStopRecClick}>
+        <button
+          onClick={onStopRecClick}
+          disabled={loading}
+        >
           Stop
         </button>
       </div>


### PR DESCRIPTION
This adds a loading indicator to the top right of the page, designed in such a way that we could easily swap it with a [prettier animation](https://material-ui.com/components/progress/) later on.

It required quite a bit of tweaking due to how the video playback itself works, namely the new use of `React.memo`, but seems to work just fine now.

Deployment tested and live at: https://cc-final-project.azurewebsites.net/