### PR TITLE
Fix issue with buttons not being pressable in Chrome

### DIFF
--- a/react-app/src/components/FaceRecVideoPlayer.jsx
+++ b/react-app/src/components/FaceRecVideoPlayer.jsx
@@ -102,6 +102,7 @@ function FaceRecVideoPlayer(props) {
           position: 'absolute',
           height: videoHeight,
           width: videoWidth,
+          top: 0,
         }}
       >
         <FaceRecLoadingOverlay


### PR DESCRIPTION
Apparently Chrome does not have the same default style for `absolute` elements as Firefox does, so it was overlaying the entire element on top of the buttons and disallowing them from being pushed.

This simply sets `top` to `0` to ensure it goes all the way to the top of the parent element, as it had already been doing in Firefox.

Closes #8 